### PR TITLE
Bugfixes in environment variables and gzip support

### DIFF
--- a/scripts/miniskirt.sh
+++ b/scripts/miniskirt.sh
@@ -2,12 +2,12 @@
 fasta_path=${1}
 output_path=${2}
 
-nuc_query_path=${IPDKIR_PATH}"/kir_nuc.fasta"
-gen_query_path=${IPDKIR_PATH}"/kir_gen.fasta"
-Eds1_query_path=${IPDKIR_PATH}"/fasta/KIR3DS1_nuc.fasta"
-zds4_fusion_path=${IPDKIR_PATH}"/fasta/KIR2DS4-00101e124567_3DL1-03501e89_nuc.fasta"
-zdl3_fusion_path=${IPDKIR_PATH}"/fasta/KIR2DL3-00101e1245_2DP1-00201e6789_nuc.fasta"
-novel_allele_path=${WD}"/novel.fa"
+nuc_query_path=${SKIRT_WD}"/IPDKIR/kir_nuc.fasta"
+gen_query_path=${SKIRT_WD}"/IPDKIR/kir_gen.fasta"
+Eds1_query_path=${SKIRT_WD}"/IPDKIR/fasta/KIR3DS1_nuc.fasta"
+zds4_fusion_path=${SKIRT_WD}"/IPDKIR/fasta/KIR2DS4-00101e124567_3DL1-03501e89_nuc.fasta"
+zdl3_fusion_path=${SKIRT_WD}"/IPDKIR/fasta/KIR2DL3-00101e1245_2DP1-00201e6789_nuc.fasta"
+novel_allele_path=${SKIRT_WD}"/novel.fa"
 
 fastafile=$(basename -- "$fasta_path")
 outputname="${fastafile%.fa*}"
@@ -26,5 +26,5 @@ minimap2 -cx splice:hq -G16k -y --cs -t32 -2 ${fasta_path} ${novel_allele_path} 
 minimap2 -cx splice:hq -G16k -k8 --end-seed-pen 5 -y --cs -t32 -2 ${fasta_path} ${Eds1_query_path} >> ${paf_path} 2>>${paf_path}.err
 minimap2 -cx splice:hq -G16k -y --cs -t32 -2 ${fasta_path} ${gen_query_path} > ${output_prefix}.gen.paf 2>${output_prefix}.gen.paf.err
 
-python3 ${SCRIPT_PATH}/scripts/skirt.py -asm ${fasta_path} -g ${output_prefix}.gen.paf ${paf_path} ${output_prefix} > ${output_prefix}.skirt.err
+python3 ${SKIRT_WD}/scripts/skirt.py -asm ${fasta_path} -g ${output_prefix}.gen.paf ${paf_path} ${output_prefix} > ${output_prefix}.skirt.err
 

--- a/scripts/skirt.py
+++ b/scripts/skirt.py
@@ -583,10 +583,10 @@ def main():
 
 		if gzipped:
 			# File is gzipped, open using gzip
-		with gzip.open(args.asm, 'rt') as f:
-			# Use Biopython's SeqIO module to read the fasta file
-			records = SeqIO.parse(f, 'fasta')
-			result_df = handle_variant_alleles(result_df, records, args.output_file)
+			with gzip.open(args.asm, 'rt') as f:
+				# Use Biopython's SeqIO module to read the fasta file
+				records = SeqIO.parse(f, 'fasta')
+				result_df = handle_variant_alleles(result_df, records, args.output_file)
 		else:
 			# File is not gzipped, open normally
 			with open(args.asm, 'r') as f:


### PR DESCRIPTION
Hey guys! Cool tool. Your README just references setting the `SKIRT_WD` env variable, but `scripts/miniskirt.sh` references `IPDKIR_PATH` and `WD`. 

Also there was an indentation bug in `scripts/skirt.py` when handling gzipped fastas that I fixed.